### PR TITLE
Support disabling legacy CRD watcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ENV PYTHONUNBUFFERED=1 \
 
 RUN pip install kubernetes
 COPY main.py /
-CMD python /main.py
+CMD ["python", "/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.11-alpine
 
 ENV PYTHONUNBUFFERED=1 \
     ISSUER_NAME=letsencrypt \

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ import signal
 import sys
 import threading
 
-from unicodedata import name
 from kubernetes import client, config, watch
 from kubernetes.client.rest import ApiException
 
@@ -39,10 +38,10 @@ def create_certificate(crds, namespace, secretname, routes):
     Create a certificate request for certmanager based on the IngressRoute
     """
     try:
-        secret = crds.get_namespaced_custom_object(CERT_GROUP, CERT_VERSION, namespace, CERT_PLURAL, secretname)
+        # secret = crds.get_namespaced_custom_object(CERT_GROUP, CERT_VERSION, namespace, CERT_PLURAL, secretname)
         logging.info(f"{secretname} : certificate request already exists.")
         return
-    except ApiException as e:
+    except ApiException:
         pass
 
     for route in routes:
@@ -88,7 +87,7 @@ def watch_crd(group, version, plural):
     """
     Watch Traefik IngressRoute CRD and create/delete certificates based on them
     """
-    #config.load_kube_config()
+    # config.load_kube_config()
     config.load_incluster_config()
     crds = client.CustomObjectsApi()
     resource_version = ""
@@ -117,7 +116,7 @@ def watch_crd(group, version, plural):
                 # if no secretName is set, add one to the IngressRoute
                 if not secretname and PATCH_SECRETNAME:
                     logging.info(f"{namespace}/{name} : no secretName found in IngressRoute, patch to add one")
-                    patch = { "spec": { "tls": { "secretName": name }}}
+                    patch = {"spec": {"tls": {"secretName": name}}}
                     crds.patch_namespaced_custom_object(group, version, namespace, plural, name, patch)
                     secretname = name
                 if secretname:

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def create_certificate(crds, namespace, secretname, routes):
     Create a certificate request for certmanager based on the IngressRoute
     """
     try:
-        # secret = crds.get_namespaced_custom_object(CERT_GROUP, CERT_VERSION, namespace, CERT_PLURAL, secretname)
+        assert crds.get_namespaced_custom_object(CERT_GROUP, CERT_VERSION, namespace, CERT_PLURAL, secretname)
         logging.info(f"{secretname} : certificate request already exists.")
         return
     except ApiException:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-kubernetes
+kubernetes==31.x


### PR DESCRIPTION
On a new Kubernetes cluster (v1.31 k3s) with a fresh installation of Traefik Helm chart v29.0.1 (`https://helm.traefik.io/traefik`), the traefik-certmanager pod was failing with the error output below. The solution was to disable the deprecated Traefik CRD watcher for ` traefik.containo.us/v1alpha1/ingressroute`. 

For reference, I have [updated the DecentCI Helm chart that deploys traefik-certmanager to include support for this option](https://gitlab.com/decentci/charts/-/tree/dc85eeedf99677cd4834b96e4a0bc5fee3f6e5b7/charts/traefik-certmanager).


```
INFO:root:Watching traefik.containo.us/v1alpha1/ingressroutes
INFO:root:Watching traefik.io/v1alpha1/ingressroutes
Exception in thread Thread-1 (watch_crd):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1052, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 989, in run
    self._target(*self._args, **self._kwargs)
  File "/main.py", line 101, in watch_crd
    for event in stream:
  File "/usr/local/lib/python3.12/site-packages/kubernetes/watch/watch.py", line 163, in stream
    resp = func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api/custom_objects_api.py", line 2065, in list_cluster_custom_object
    return self.list_cluster_custom_object_with_http_info(group, version, plural, **kwargs)  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api/custom_objects_api.py", line 2196, in list_cluster_custom_object_with_http_info
    return self.api_client.call_api(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
                    ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 373, in request
    return self.rest_client.GET(url,
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/rest.py", line 244, in GET
    return self.request("GET", url,
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/rest.py", line 238, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'Audit-Id': 'fa43b1d0-9c19-47ae-81f3-5b9b18e46cf7', 'Cache-Control': 'no-cache, private', 'Content-Type': 'text/plain; charset=utf-8', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': '6d872c8d-935d-48d2-92b7-bae37b5b352e', 'X-Kubernetes-Pf-Prioritylevel-Uid': 'c141972c-708d-4587-9289-4812aa53d0e5', 'Date': 'Tue, 17 Dec 2024 12:54:42 GMT', 'Content-Length': '19'})
HTTP response body: b'404 page not found\n'

INFO:root:foo : certificate request already exists.
INFO:root:One of the threads exited False, True
Stream closed EOF for traefik/traefik-certmanager-6cddc84d55-rfzr2 (traefik-certmanager)
```